### PR TITLE
8 bug documents multilingues mauvaise extraction des codes langue pour le titre résumés et les mots clés

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,19 +37,19 @@ jobs:
       - name: Templating
         run: |
           chmod +x .script/*.sh
-          make bundle.1.0 > marcxml2tei-1.0.xsl
-          make bundle.2.0 > marcxml2tei-2.0.xsl
-          make oracle > marcxml2tei-oracle.xsl
-          cp ./commons/oracle-cleaner.xsl .
+          make bundle.1.0
+          make bundle.2.0
+          make oracle
+          cp ./commons/oracle-cleaner.xsl /bundle/oracle-cleaner.xsl
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
-            marcxml2tei-1.0.xsl
-            marcxml2tei-2.0.xsl
-            marcxml2tei-oracle.xsl
-            oracle-cleaner.xsl
+            bundle/marcxml2tei-1.0.xsl
+            bundle/marcxml2tei-2.0.xsl
+            bundle/marcxml2tei-oracle.xsl
+            bundle/oracle-cleaner.xsl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+bundle
+output

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ convert: create-output-dir
 		done;	\
 	done;
 
-test: tests/*.xspec
+test: tests/*.xspec bundle.1.0 bundle.2.0
 	@for i in tests/*.xspec; do xspec.sh $$i; done
 
 clear-test:
@@ -30,12 +30,15 @@ rebuild-mapping:
 
 # builds an all-in-one file which embeds the mapping data and the cleaner
 bundle.1.0: rebuild-mapping
-	@.script/template.sh template/bundle.1.0.xsl | sed -r 's! xmlns:xi="http://www.w3.org/2001/XInclude"!!g'
+	mkdir -p bundle
+	@.script/template.sh template/bundle.1.0.xsl | sed -r 's! xmlns:xi="http://www.w3.org/2001/XInclude"!!g' > bundle/marcxml2tei-1.0.xsl
 
 # builds an all-in-one file which embeds the mapping data and the cleaner
 bundle.2.0: rebuild-mapping
-	@.script/template.sh template/bundle.2.0.xsl | sed -r 's! xmlns:xi="http://www.w3.org/2001/XInclude"!!g'
+	mkdir -p bundle
+	@.script/template.sh template/bundle.2.0.xsl | sed -r 's! xmlns:xi="http://www.w3.org/2001/XInclude"!!g' > bundle/marcxml2tei-2.0.xsl
 
 # builds an xslt compliant with Oracle
 oracle:
-	@.script/template.sh template/oracle.xsl | sed -r 's! xmlns:xi="http://www.w3.org/2001/XInclude"! xmlns:xml="http://www.w3.org/XML/1998/namespace"!g'
+	mkdir -p bundle
+	@.script/template.sh template/oracle.xsl | sed -r 's! xmlns:xi="http://www.w3.org/2001/XInclude"! xmlns:xml="http://www.w3.org/XML/1998/namespace"!g' > bundle/marcxml2tei-oracle.xsl

--- a/marcxml_sample/257133615.xml
+++ b/marcxml_sample/257133615.xml
@@ -1,0 +1,227 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record>
+  <leader>     clm0 22        450 </leader>
+  <controlfield tag="001">257133615</controlfield>
+  <controlfield tag="002">27</controlfield>
+  <controlfield tag="003">http://www.sudoc.fr/257133615</controlfield>
+  <controlfield tag="004">20210906</controlfield>
+  <controlfield tag="005">20220310231504.000</controlfield>
+  <controlfield tag="006">385162101</controlfield>
+  <controlfield tag="007">384212103</controlfield>
+  <controlfield tag="008">Oax3</controlfield>
+  <datafield tag="029" ind1=" " ind2=" ">
+    <subfield code="a">FR</subfield>
+    <subfield code="b">2021GRAL5078 (thèse d&apos;exercice)</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(OCoLC)1269430195</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">dumas-03601218</subfield>
+  </datafield>
+  <datafield tag="100" ind1=" " ind2=" ">
+    <subfield code="a">20210906d2021    k  y0frey50      ba</subfield>
+  </datafield>
+  <datafield tag="101" ind1="0" ind2=" ">
+    <subfield code="a">eng</subfield>
+    <subfield code="a">fre</subfield>
+    <subfield code="d">fre</subfield>
+    <subfield code="d">eng</subfield>
+  </datafield>
+  <datafield tag="102" ind1=" " ind2=" ">
+    <subfield code="a">FR</subfield>
+  </datafield>
+  <datafield tag="105" ind1=" " ind2=" ">
+    <subfield code="a">a   ma  000yy</subfield>
+  </datafield>
+  <datafield tag="106" ind1=" " ind2=" ">
+    <subfield code="a">s</subfield>
+  </datafield>
+  <datafield tag="135" ind1=" " ind2=" ">
+    <subfield code="a">dr|||||||||||</subfield>
+  </datafield>
+  <datafield tag="181" ind1=" " ind2=" ">
+    <subfield code="6">z01</subfield>
+    <subfield code="c">txt</subfield>
+    <subfield code="2">rdacontent</subfield>
+  </datafield>
+  <datafield tag="181" ind1=" " ind2="1">
+    <subfield code="6">z01</subfield>
+    <subfield code="a">i#</subfield>
+    <subfield code="b">xxxe##</subfield>
+  </datafield>
+  <datafield tag="182" ind1=" " ind2=" ">
+    <subfield code="6">z01</subfield>
+    <subfield code="c">c</subfield>
+    <subfield code="2">rdamedia</subfield>
+  </datafield>
+  <datafield tag="182" ind1=" " ind2="1">
+    <subfield code="6">z01</subfield>
+    <subfield code="a">b</subfield>
+  </datafield>
+  <datafield tag="183" ind1=" " ind2=" ">
+    <subfield code="6">z01</subfield>
+    <subfield code="a">ceb</subfield>
+    <subfield code="2">rdamedia</subfield>
+  </datafield>
+  <datafield tag="200" ind1="1" ind2=" ">
+    <subfield code="a">Capacité vitale forcée et diffusion du monoxyde de carbone dans la fibrose pulmonaire idiopathique</subfield>
+    <subfield code="e">ce que change l’utilisation des normes GLI</subfield>
+    <subfield code="f">Salomé Nussbaum</subfield>
+    <subfield code="g">sous la direction de Bruno Degano</subfield>
+  </datafield>
+  <datafield tag="214" ind1=" " ind2="1">
+    <subfield code="d">2021</subfield>
+  </datafield>
+  <datafield tag="230" ind1=" " ind2=" ">
+    <subfield code="a">Données textuelles</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">Dans la version mise en ligne, les données à caractère personnel ont été masquées ; la version originale est consultable sur demande à la bibliothèque universitaire de médecine pharmacie de Grenoble</subfield>
+  </datafield>
+  <datafield tag="303" ind1=" " ind2=" ">
+    <subfield code="a">L&apos;impression du document génère 32 p.</subfield>
+  </datafield>
+  <datafield tag="304" ind1=" " ind2=" ">
+    <subfield code="a">GLI = Global lung initiative (GLI)</subfield>
+  </datafield>
+  <datafield tag="314" ind1=" " ind2=" ">
+    <subfield code="a">Autre contribution : Christophe Pison (Président du jury)</subfield>
+  </datafield>
+  <datafield tag="320" ind1=" " ind2=" ">
+    <subfield code="a">Bibliogr. 27 réf.</subfield>
+  </datafield>
+  <datafield tag="328" ind1=" " ind2="0">
+    <subfield code="b">Thèse d&apos;exercice</subfield>
+    <subfield code="c">Médecine. Pneumologie</subfield>
+    <subfield code="e">Université Grenoble Alpes</subfield>
+    <subfield code="d">2021</subfield>
+  </datafield>
+  <datafield tag="330" ind1=" " ind2=" ">
+    <subfield code="a">Contexte : CVF et DLCO sont les paramètres physiologiques les plus utilisés pour l’évaluation des patients porteurs d’une fibrose pulmonaire idiopathique (FPI). Ils sont exprimés en pourcentage d’une valeur de référence ou en Z-score, et l’utilisation des équations du Global Lung Initiative (GLI) est recommandée depuis peu. Les objectifs étaient de décrire la relation entre CVF et DLCO, et d’évaluer l’influence du changement des valeurs de référence sur la décision médicale, notamment concernant la sélection des candidats à la transplantation pulmonaire. Méthode : nous avons inclus tous les sujets de la cohorte COLIBRI-PID porteurs d’une FPI. Pour chacun, une mesure de DLCO et une mesure de CVF ont été recueillies. Résultats : cette observation transversale de 248 patients avec un large éventail de sévérité, a permis de montrer la relation non linéaire entre CVF et DLCO. Ces résultats sont susceptibles de caractériser l’évolution de la CVF et de la DLCO lorsque la maladie progresse, pour un patient donné : on pourrait alors identifier une première phase de déclin de la DLCO avec une CVF plutôt stable, puis une phase plus tardive où ces deux paramètres chutent ensemble. 17 patients ont changé de groupe pour être adressés vers un centre de transplantation pulmonaire en utilisant les équations GLI à la place des anciennes normes. Les valeurs limites considérées par le consensus de transplantation pulmonaire étaient de 40 % pour la DLCO ou 80 % pour la CVF. Conclusion : La DLCO semble essentielle à l’évaluation des formes de FPI à CVF préservée. L’utilisation de GLI est un plus sensible que les normes plus anciennes pour sélectionner les candidats à la transplantation pulmonaire.</subfield>
+  </datafield>
+  <datafield tag="330" ind1=" " ind2=" ">
+    <subfield code="a">Background: FVC and DLCO are the most useful physiological parameters to assess idiopathic pulmonary fibrosis (IPF). They are expressed as percentage of reference value or Z-score, and the use of Global Lung Initiative (GLI) equations is now recommended. The objectives were to describe the relationship between FVC and DLCO, and to assess the influence of the change in reference values on medical decision, namely regarding the selection of lung transplant candidates. Methods: we included all subjects diagnosed with IPF from the cohort COLIBRI-ILD. Measurements of FVC and DLCO performed at the same time were collected for each patient. Results: in 248 IPF patients with a broad range of severity, this transversal observation highlighted the nonlinear relationship between FVC and DLCO. Those results could allow us to characterise the course of FVC and DLCO throughout disease progression for a given patient. In the first stages, FVC would remain steady while DLCO would drop. In contrast, both would decline in the last stages. 17 patients switch group to be reffered to a lung transplant center when we use GLI instead of the older standards, with the cut-off limit of 40 % for DLCO or 80 % for FVC. Conclusion: DLCO seems essential in monitoring the IPF forms when FVC is preserved. The use of GLI is little more sensitive than older standards to select lung transplant candidates</subfield>
+  </datafield>
+  <datafield tag="337" ind1=" " ind2=" ">
+    <subfield code="a">Configuration requise : logiciel capable de lire un fichier au format PDF</subfield>
+  </datafield>
+  <datafield tag="541" ind1="|" ind2=" ">
+    <subfield code="a">Insight into the relationship between forced vital capacity and transfer factor of the lung for carbon monoxide in patients with idiopathic pulmonary fibrosis</subfield>
+    <subfield code="z">eng</subfield>
+  </datafield>
+  <datafield tag="606" ind1=" " ind2=" ">
+    <subfield code="3">034206256</subfield>
+    <subfield code="a">Fibrose pulmonaire</subfield>
+    <subfield code="2">rameau</subfield>
+  </datafield>
+  <datafield tag="606" ind1=" " ind2=" ">
+    <subfield code="3">02724198X</subfield>
+    <subfield code="a">Exploration fonctionnelle respiratoire</subfield>
+    <subfield code="2">rameau</subfield>
+  </datafield>
+  <datafield tag="606" ind1=" " ind2=" ">
+    <subfield code="3">027570770</subfield>
+    <subfield code="a">Monoxyde de carbone</subfield>
+    <subfield code="2">rameau</subfield>
+  </datafield>
+  <datafield tag="606" ind1=" " ind2=" ">
+    <subfield code="3">027803627</subfield>
+    <subfield code="a">Diffusion (physique)</subfield>
+    <subfield code="3">027315584</subfield>
+    <subfield code="x">Mesure</subfield>
+    <subfield code="2">rameau</subfield>
+  </datafield>
+  <datafield tag="606" ind1=" " ind2=" ">
+    <subfield code="3">07897321X</subfield>
+    <subfield code="a">Capacité pulmonaire totale</subfield>
+    <subfield code="2">rameau</subfield>
+  </datafield>
+  <datafield tag="606" ind1=" " ind2=" ">
+    <subfield code="3">16929188X</subfield>
+    <subfield code="a">Transplantation pulmonaire</subfield>
+    <subfield code="2">rameau</subfield>
+  </datafield>
+  <datafield tag="606" ind1=" " ind2=" ">
+    <subfield code="3">143192256</subfield>
+    <subfield code="a">Fibrose pulmonaire idiopathique</subfield>
+    <subfield code="3">040839486</subfield>
+    <subfield code="x">Dissertation universitaire</subfield>
+    <subfield code="2">fmesh</subfield>
+  </datafield>
+  <datafield tag="606" ind1=" " ind2=" ">
+    <subfield code="3">040798976</subfield>
+    <subfield code="a">Capacité vitale</subfield>
+    <subfield code="3">040839486</subfield>
+    <subfield code="x">Dissertation universitaire</subfield>
+    <subfield code="2">fmesh</subfield>
+  </datafield>
+  <datafield tag="608" ind1=" " ind2=" ">
+    <subfield code="3">027253139</subfield>
+    <subfield code="a">Thèses et écrits académiques</subfield>
+    <subfield code="2">rameau</subfield>
+  </datafield>
+  <datafield tag="610" ind1="0" ind2=" ">
+    <subfield code="a">Capacité de diffusion du poumon pour le monoxyde de carbone (DLCO)</subfield>
+    <subfield code="a">Normes GLI</subfield>
+    <subfield code="a">Global lung initiative (GLI)</subfield>
+    <subfield code="a">Diffusing capacity of the lung for carbon monoxide (DLCO)</subfield>
+  </datafield>
+  <datafield tag="676" ind1=" " ind2=" ">
+    <subfield code="a">610</subfield>
+    <subfield code="v">22</subfield>
+  </datafield>
+  <datafield tag="700" ind1=" " ind2="1">
+    <subfield code="3">25713364X</subfield>
+    <subfield code="a">Nussbaum</subfield>
+    <subfield code="b">Salomé</subfield>
+    <subfield code="f">1990-....</subfield>
+    <subfield code="4">070</subfield>
+  </datafield>
+  <datafield tag="701" ind1=" " ind2="1">
+    <subfield code="3">117594237</subfield>
+    <subfield code="a">Degano</subfield>
+    <subfield code="b">Bruno</subfield>
+    <subfield code="f">1968-....</subfield>
+    <subfield code="4">727</subfield>
+  </datafield>
+  <datafield tag="701" ind1=" " ind2="1">
+    <subfield code="3">066846692</subfield>
+    <subfield code="a">Pison</subfield>
+    <subfield code="b">Christophe</subfield>
+    <subfield code="f">1955-....</subfield>
+    <subfield code="4">956</subfield>
+  </datafield>
+  <datafield tag="711" ind1="0" ind2="2">
+    <subfield code="3">240648315</subfield>
+    <subfield code="a">Université Grenoble Alpes</subfield>
+    <subfield code="c">2020-....</subfield>
+    <subfield code="4">295</subfield>
+  </datafield>
+  <datafield tag="801" ind1=" " ind2="3">
+    <subfield code="a">FR</subfield>
+    <subfield code="b">Abes</subfield>
+    <subfield code="c">20220310</subfield>
+    <subfield code="g">AFNOR</subfield>
+  </datafield>
+  <datafield tag="856" ind1="4" ind2=" ">
+    <subfield code="q">PDF</subfield>
+    <subfield code="u">https://dumas.ccsd.cnrs.fr/dumas-03601218/document</subfield>
+  </datafield>
+  <datafield tag="930" ind1=" " ind2=" ">
+    <subfield code="5">385162101:703886819</subfield>
+    <subfield code="b">385162101</subfield>
+    <subfield code="a">TM21/5078/E</subfield>
+    <subfield code="j">g</subfield>
+  </datafield>
+  <datafield tag="940" ind1=" " ind2=" ">
+    <subfield code="5">385162101:703886819</subfield>
+    <subfield code="a">20210906</subfield>
+    <subfield code="b">x</subfield>
+  </datafield>
+  <datafield tag="941" ind1=" " ind2=" ">
+    <subfield code="5">385162101:703886819</subfield>
+    <subfield code="a">20210906</subfield>
+    <subfield code="b">17:02:09.000</subfield>
+  </datafield>
+</record>

--- a/template/oracle.xsl
+++ b/template/oracle.xsl
@@ -9,20 +9,23 @@
 	<xsl:output method="xml" indent="yes" />
 
 	<!-- On redéfinit le comportement de primaryLanguageCode : dans le contexte d'Oracle on récupère juste la valeur en 101$a (qui a été modifiée péalablement par Oracle) -->
-	<xsl:variable name="primaryLanguageCode">
-		<xsl:variable name="primaryLanguageCode639_2">
-			<xsl:choose>
-				<xsl:when test="/record/datafield[@tag='101']/subfield[@code='a']">
-					<xsl:value-of select="/record/datafield[@tag='101']/subfield[@code='a']"/>
-				</xsl:when>
-				<xsl:otherwise>
-					<xsl:text>fr</xsl:text>
-				</xsl:otherwise>
-			</xsl:choose>
-		</xsl:variable>
-		<!-- In Oracle context we return the original value which is modified beforehand by Oracle -->
-		<xsl:value-of select="$primaryLanguageCode639_2"/>
-	</xsl:variable>
+    <xsl:variable name="mainTitleLang">
+        <xsl:variable name="mainTitleLang639_2">
+            <xsl:choose>
+                <xsl:when test="count(/record/datafield[@tag='101']/subfield[@code='a']) = 1">
+                    <xsl:value-of select="/record/datafield[@tag='101']/subfield[@code='a'][1]"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <!-- Par défaut on considère que le document est en Français s'il y a plusieurs 101$a -->
+                    <xsl:text>fre</xsl:text>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+
+        <xsl:call-template name="codeLangue">
+            <xsl:with-param name="code" select="$mainTitleLang639_2"/>
+        </xsl:call-template>
+    </xsl:variable>
 
 	<!-- Récupération du code langue en 101$d ou en 541$z. Valeur par défaut = valeur du paramètre secondaryLanguage ou 'eng' -->
 	<xsl:variable name="secondaryLanguageCode">

--- a/template/oracle.xsl
+++ b/template/oracle.xsl
@@ -8,24 +8,13 @@
 	<xsl:strip-space elements="*" />
 	<xsl:output method="xml" indent="yes" />
 
-	<!-- On redéfinit le comportement de primaryLanguageCode : dans le contexte d'Oracle on récupère juste la valeur en 101$a (qui a été modifiée péalablement par Oracle) -->
-    <xsl:variable name="mainTitleLang">
-        <xsl:variable name="mainTitleLang639_2">
-            <xsl:choose>
-                <xsl:when test="count(/record/datafield[@tag='101']/subfield[@code='a']) = 1">
-                    <xsl:value-of select="/record/datafield[@tag='101']/subfield[@code='a'][1]"/>
-                </xsl:when>
-                <xsl:otherwise>
-                    <!-- Par défaut on considère que le document est en Français s'il y a plusieurs 101$a -->
-                    <xsl:text>fre</xsl:text>
-                </xsl:otherwise>
-            </xsl:choose>
-        </xsl:variable>
-
-        <xsl:call-template name="codeLangue">
-            <xsl:with-param name="code" select="$mainTitleLang639_2"/>
-        </xsl:call-template>
-    </xsl:variable>
+	<!-- On redéfinit le comportement de codeLangue pour Oracle. -->
+	<!-- Dans le contexte d'Oracle code langue ne fait rien.-->
+	<!-- Il retourne les données qu'il reçoit en entrée, car les données sont déjà modifiées en amont par Oracle. -->
+	<xsl:template name="codeLangue">
+		<xsl:param name="code" />
+		<xsl:value-of select="$code"/>
+	</xsl:template>
 
 	<xsl:template name="codeOai">
 		<xsl:param name="code" />
@@ -33,9 +22,8 @@
 		<xsl:if test="not(contains('0123456789', substring($code, 1, 1)))">
 			<xsl:value-of select="$code"/>
 		</xsl:if>
-
 	</xsl:template>
 
 	<!-- Importe le contenu de ./xslt/marcxml2tei-1.0.xsl sauf le prologue xslt, primaryLanguageCode et secondaryLanguageCode -->
-	<xi:include href="../xslt/marcxml2tei-1.0.xsl" xpointer="xmlns(xsl=http://www.w3.org/1999/XSL/Transform)xpointer(//xsl:stylesheet/*[(name() != 'xsl:import' and name() != 'xsl:output' and name() != 'xsl:strip-space') and (@name != 'primaryLanguageCode' and @name != 'secondaryLanguageCode' and @name != 'codeOai' and @name != 'codeLangue')])"/>
+	<xi:include href="../xslt/marcxml2tei-1.0.xsl" xpointer="xmlns(xsl=http://www.w3.org/1999/XSL/Transform)xpointer(//xsl:stylesheet/*[(name() != 'xsl:import' and name() != 'xsl:output' and name() != 'xsl:strip-space') and (@name != 'codeOai' and @name != 'codeLangue')])"/>
 </xsl:stylesheet>

--- a/template/oracle.xsl
+++ b/template/oracle.xsl
@@ -27,27 +27,6 @@
         </xsl:call-template>
     </xsl:variable>
 
-	<!-- Récupération du code langue en 101$d ou en 541$z. Valeur par défaut = valeur du paramètre secondaryLanguage ou 'eng' -->
-	<xsl:variable name="secondaryLanguageCode">
-		<xsl:variable name="secondaryLanguageCode639_2">
-			<xsl:choose>
-				<xsl:when test="/record/datafield[@tag='101']/subfield[@code='d'][2]">
-					<xsl:value-of select="/record/datafield[@tag='101']/subfield[@code='d'][2]"/>
-				</xsl:when>
-				<xsl:when test="/record/datafield[@tag = '541']/subfield[@code = 'z'][1]">
-					<xsl:value-of select="/record/datafield[@tag = '541']/subfield[@code = 'z'][1]"/>
-				</xsl:when>
-				<xsl:otherwise>
-					<xsl:text>en</xsl:text>
-				</xsl:otherwise>
-			</xsl:choose>
-		</xsl:variable>
-		<!-- In Oracle context we return the original value which is modified beforehand by Oracle -->
-		<xsl:value-of select="$secondaryLanguageCode639_2"/>
-	</xsl:variable>
-
-
-
 	<xsl:template name="codeOai">
 		<xsl:param name="code" />
 		<!-- ORACLE preprocessing plsql doesn't remove set data so we filter them -->

--- a/tests/marcxml2tei-1.0.xspec
+++ b/tests/marcxml2tei-1.0.xspec
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
-    stylesheet="../xslt/marcxml2tei-1.0.xsl">
+    stylesheet="../bundle/marcxml2tei-1.0.xsl">
     <x:import href="./marcxml2tei.xspec"/>
 </x:description>

--- a/tests/marcxml2tei-2.0.xspec
+++ b/tests/marcxml2tei-2.0.xspec
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
-    stylesheet="../xslt/marcxml2tei-2.0.xsl">
+    stylesheet="../bundle/marcxml2tei-2.0.xsl">
     <x:import href="./marcxml2tei.xspec"/>
 </x:description>

--- a/tests/marcxml2tei.xspec
+++ b/tests/marcxml2tei.xspec
@@ -1,13 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
-    stylesheet="../xslt/marcxml2tei-1.0.xsl">
-
-    <x:param name="primaryLanguage">fre</x:param>
-    <x:param name="primaryLanguageCode">fr</x:param>
-    <x:param name="secondaryLanguage">eng</x:param>
-    <x:param name="secondaryLanguageCode">en</x:param>
-
+    stylesheet="../bundle/marcxml2tei-1.0.xsl">
     <x:scenario label="joinTitleElements with a title and subtitle">
         <x:call template="joinTitleElements">
             <x:param name="titles">
@@ -61,6 +55,9 @@
     <x:scenario label="Original title only">
         <x:context>
             <record>
+                <datafield tag="101" ind1="0" ind2=" ">
+                    <subfield code="a">fre</subfield>
+                </datafield>
                 <datafield tag="200" ind1="1" ind2=" ">
                     <subfield code="a">A title</subfield>
                     <subfield code="e">A subtitle</subfield>
@@ -80,6 +77,9 @@
     <x:scenario label="Original and translated title">
         <x:context>
             <record>
+                <datafield tag="101" ind1="0" ind2=" ">
+                    <subfield code="a">fre</subfield>
+                </datafield>
                 <datafield tag="200" ind1="1" ind2=" ">
                     <subfield code="a">Un titre</subfield>
                     <subfield code="e">Un sous-titre</subfield>
@@ -104,7 +104,7 @@
         </x:expect>
     </x:scenario>
 
-    <!-- test title lang -->
+    
 
     <x:scenario label="Author">
         <x:context>
@@ -153,6 +153,9 @@
     <x:scenario label="Monogr">
         <x:context>
             <record>
+                <datafield tag="101" ind1="0" ind2=" ">
+                    <subfield code="a">fre</subfield>
+                </datafield>
                 <datafield tag="328" ind1=" " ind2="1">
                     <subfield code="d">2020</subfield>
                 </datafield>
@@ -400,6 +403,40 @@
                     <date type="dateDefended" />
                 </imprint>
             </monogr>
+        </x:expect>
+    </x:scenario>
+
+    <x:scenario label="Abstract lang should be paired with 101$d">
+        <x:context>
+            <record>
+                <datafield tag="101" ind1="0" ind2=" ">
+                    <subfield code="a">eng</subfield>
+                    <subfield code="a">fre</subfield>
+                    <subfield code="d">fre</subfield>
+                    <subfield code="d">eng</subfield>
+                </datafield>
+                <datafield tag="330" ind1=" " ind2=" ">
+                    <subfield code="a">Contexte : CVF et DLCO sont les paramètres physiologiques les plus utilisés pour l’évaluation des patients porteurs d’une fibrose pulmonaire idiopathique (FPI). Ils sont exprimés en pourcentage d’une valeur de référence ou en Z-score, et l’utilisation des équations du Global Lung Initiative (GLI) est recommandée depuis peu. Les objectifs étaient de décrire la relation entre CVF et DLCO, et d’évaluer l’influence du changement des valeurs de référence sur la décision médicale, notamment concernant la sélection des candidats à la transplantation pulmonaire. Méthode : nous avons inclus tous les sujets de la cohorte COLIBRI-PID porteurs d’une FPI. Pour chacun, une mesure de DLCO et une mesure de CVF ont été recueillies. Résultats : cette observation transversale de 248 patients avec un large éventail de sévérité, a permis de montrer la relation non linéaire entre CVF et DLCO. Ces résultats sont susceptibles de caractériser l’évolution de la CVF et de la DLCO lorsque la maladie progresse, pour un patient donné : on pourrait alors identifier une première phase de déclin de la DLCO avec une CVF plutôt stable, puis une phase plus tardive où ces deux paramètres chutent ensemble. 17 patients ont changé de groupe pour être adressés vers un centre de transplantation pulmonaire en utilisant les équations GLI à la place des anciennes normes. Les valeurs limites considérées par le consensus de transplantation pulmonaire étaient de 40 % pour la DLCO ou 80 % pour la CVF. Conclusion : La DLCO semble essentielle à l’évaluation des formes de FPI à CVF préservée. L’utilisation de GLI est un plus sensible que les normes plus anciennes pour sélectionner les candidats à la transplantation pulmonaire.</subfield>
+                  </datafield>
+                  <datafield tag="330" ind1=" " ind2=" ">
+                    <subfield code="a">Background: FVC and DLCO are the most useful physiological parameters to assess idiopathic pulmonary fibrosis (IPF). They are expressed as percentage of reference value or Z-score, and the use of Global Lung Initiative (GLI) equations is now recommended. The objectives were to describe the relationship between FVC and DLCO, and to assess the influence of the change in reference values on medical decision, namely regarding the selection of lung transplant candidates. Methods: we included all subjects diagnosed with IPF from the cohort COLIBRI-ILD. Measurements of FVC and DLCO performed at the same time were collected for each patient. Results: in 248 IPF patients with a broad range of severity, this transversal observation highlighted the nonlinear relationship between FVC and DLCO. Those results could allow us to characterise the course of FVC and DLCO throughout disease progression for a given patient. In the first stages, FVC would remain steady while DLCO would drop. In contrast, both would decline in the last stages. 17 patients switch group to be reffered to a lung transplant center when we use GLI instead of the older standards, with the cut-off limit of 40 % for DLCO or 80 % for FVC. Conclusion: DLCO seems essential in monitoring the IPF forms when FVC is preserved. The use of GLI is little more sensitive than older standards to select lung transplant candidates</subfield>
+                  </datafield>
+            </record>
+        </x:context>
+
+        <x:call template="abstract"/>
+
+        <x:expect label="Monogr should extract pages.">
+            <abstract xmlns="http://www.tei-c.org/ns/1.0"
+          xmlns:ext="http://exslt.org/common"
+          xmlns:hal="http://hal.archives-ouvertes.fr/"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xml:lang="fr">Contexte : CVF et DLCO sont les paramètres physiologiques les plus utilisés pour l’évaluation des patients porteurs d’une fibrose pulmonaire idiopathique (FPI). Ils sont exprimés en pourcentage d’une valeur de référence ou en Z-score, et l’utilisation des équations du Global Lung Initiative (GLI) est recommandée depuis peu. Les objectifs étaient de décrire la relation entre CVF et DLCO, et d’évaluer l’influence du changement des valeurs de référence sur la décision médicale, notamment concernant la sélection des candidats à la transplantation pulmonaire. Méthode : nous avons inclus tous les sujets de la cohorte COLIBRI-PID porteurs d’une FPI. Pour chacun, une mesure de DLCO et une mesure de CVF ont été recueillies. Résultats : cette observation transversale de 248 patients avec un large éventail de sévérité, a permis de montrer la relation non linéaire entre CVF et DLCO. Ces résultats sont susceptibles de caractériser l’évolution de la CVF et de la DLCO lorsque la maladie progresse, pour un patient donné : on pourrait alors identifier une première phase de déclin de la DLCO avec une CVF plutôt stable, puis une phase plus tardive où ces deux paramètres chutent ensemble. 17 patients ont changé de groupe pour être adressés vers un centre de transplantation pulmonaire en utilisant les équations GLI à la place des anciennes normes. Les valeurs limites considérées par le consensus de transplantation pulmonaire étaient de 40 % pour la DLCO ou 80 % pour la CVF. Conclusion : La DLCO semble essentielle à l’évaluation des formes de FPI à CVF préservée. L’utilisation de GLI est un plus sensible que les normes plus anciennes pour sélectionner les candidats à la transplantation pulmonaire.</abstract>
+            <abstract xmlns="http://www.tei-c.org/ns/1.0"
+          xmlns:ext="http://exslt.org/common"
+          xmlns:hal="http://hal.archives-ouvertes.fr/"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xml:lang="en">Background: FVC and DLCO are the most useful physiological parameters to assess idiopathic pulmonary fibrosis (IPF). They are expressed as percentage of reference value or Z-score, and the use of Global Lung Initiative (GLI) equations is now recommended. The objectives were to describe the relationship between FVC and DLCO, and to assess the influence of the change in reference values on medical decision, namely regarding the selection of lung transplant candidates. Methods: we included all subjects diagnosed with IPF from the cohort COLIBRI-ILD. Measurements of FVC and DLCO performed at the same time were collected for each patient. Results: in 248 IPF patients with a broad range of severity, this transversal observation highlighted the nonlinear relationship between FVC and DLCO. Those results could allow us to characterise the course of FVC and DLCO throughout disease progression for a given patient. In the first stages, FVC would remain steady while DLCO would drop. In contrast, both would decline in the last stages. 17 patients switch group to be reffered to a lung transplant center when we use GLI instead of the older standards, with the cut-off limit of 40 % for DLCO or 80 % for FVC. Conclusion: DLCO seems essential in monitoring the IPF forms when FVC is preserved. The use of GLI is little more sensitive than older standards to select lung transplant candidates</abstract>
         </x:expect>
     </x:scenario>
 </x:description>

--- a/xslt/marcxml2tei-1.0.xsl
+++ b/xslt/marcxml2tei-1.0.xsl
@@ -204,7 +204,6 @@
 
             <textClass>
                 <xsl:call-template name="keywords" />
-
                 <xsl:for-each select="datafield[@tag = '686'][subfield[@code = '2'] = 'TEF']/subfield[@code = 'a' or @code = 'HALDOMAIN']">
                     <xsl:variable name="oai">
                         <xsl:call-template name="codeOai">
@@ -229,7 +228,7 @@
             <keywords scheme="author">
                 <!-- deduplicate keywords-->
                 <xsl:for-each select="$keywords">
-                    <term xml:lang="{$primaryLanguageCode}">
+                    <term xml:lang="fr">
                         <xsl:value-of select="." />
                     </term>
                 </xsl:for-each>

--- a/xslt/marcxml2tei-1.0.xsl
+++ b/xslt/marcxml2tei-1.0.xsl
@@ -24,20 +24,21 @@
     <!--    <xsl:param name="embargoDate" select="format-date(current-date(),'[Y0001]-[M01]-[D01]')" />-->
 
     <!-- /!\ For development and tests purposes only. Will be overwrited by Oracle template -->
-    <xsl:variable name="primaryLanguageCode">
-        <xsl:variable name="primaryLanguageCode639_2">
+    <xsl:variable name="mainTitleLang">
+        <xsl:variable name="mainTitleLang639_2">
             <xsl:choose>
-                <xsl:when test="/record/datafield[@tag='101']/subfield[@code='a']">
-                    <xsl:value-of select="/record/datafield[@tag='101']/subfield[@code='a']" />
+                <xsl:when test="count(/record/datafield[@tag='101']/subfield[@code='a']) = 1">
+                    <xsl:value-of select="/record/datafield[@tag='101']/subfield[@code='a'][1]"/>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:value-of select="$primaryLanguage" />
+                    <!-- Par défaut on considère que le document est en Français s'il y a plusieurs 101$a -->
+                    <xsl:text>fre</xsl:text>
                 </xsl:otherwise>
             </xsl:choose>
         </xsl:variable>
 
         <xsl:call-template name="codeLangue">
-            <xsl:with-param name="code" select="$primaryLanguageCode639_2"/>
+            <xsl:with-param name="code" select="$mainTitleLang639_2"/>
         </xsl:call-template>
     </xsl:variable>
 
@@ -119,21 +120,29 @@
     </xsl:template>
 
     <xsl:template name="title">
-        <title xml:lang="{$primaryLanguageCode}">
+        <title xml:lang="{$mainTitleLang}">
             <xsl:call-template name="joinTitleElements">
                 <xsl:with-param name="titles" select="datafield[@tag = '200']/subfield[@code = 'a']" />
                 <xsl:with-param name="subtitles" select="datafield[@tag = '200']/subfield[@code = 'e']" />
             </xsl:call-template>
         </title>
 
-        <xsl:if test="datafield[@tag = '541']/subfield[@code = ('a' or 'e')]">
-            <title xml:lang="{$secondaryLanguageCode}">
-                <xsl:call-template name="joinTitleElements">
-                    <xsl:with-param name="titles" select="datafield[@tag = '541']/subfield[@code = 'a']"/>
-                    <xsl:with-param name="subtitles" select="datafield[@tag = '541']/subfield[@code = 'e']" />
-                </xsl:call-template>
-            </title>
-        </xsl:if>
+        <xsl:for-each select="datafield[@tag = '541']">
+            <xsl:if test="./subfield[@code = 'a' or @code = 'e']">
+                <xsl:variable name="titleLang">
+                    <xsl:call-template name="codeLangue">
+                        <xsl:with-param name="code" select="./subfield[@code = 'z']"/>
+                    </xsl:call-template>
+                </xsl:variable>
+
+                <title xml:lang="{$titleLang}">
+                    <xsl:call-template name="joinTitleElements">
+                        <xsl:with-param name="titles" select="./subfield[@code = 'a']"/>
+                        <xsl:with-param name="subtitles" select="./subfield[@code = 'e']" />
+                    </xsl:call-template>
+                </title>
+            </xsl:if>
+        </xsl:for-each>
     </xsl:template>
 
     <xsl:template name="author">

--- a/xslt/marcxml2tei-1.0.xsl
+++ b/xslt/marcxml2tei-1.0.xsl
@@ -11,11 +11,6 @@
     <xsl:strip-space elements="*" />
     <xsl:output method="xml" indent="yes" />
 
-    <!-- Paramètres pouvant être modifiés par saxon : `saxon-xslt 252383524.xml mapping.xslt secondaryLanguageCode=es degreeCode=22 > output.tei`  -->
-    <!-- Langue principale du document. Au format ISO 639-2. Lorsqu'il est renseigné, ce paramètre n'est utilisé que s'il est impossible de trouver la langue principale du document-->
-    <xsl:param name="primaryLanguage" select="'fre'" />
-    <!-- Langue secondaire du document. Au format ISO 639-2. Lorsqu'il est renseigné, ce paramètre n'est utilisé que s'il est impossible de trouver la langue secondaire du document -->
-    <xsl:param name="secondaryLanguage" select="'eng'" />
     <!-- Liste des codes diplôme : https://api.archives-ouvertes.fr/ref/metadataList/?q=metaName_s:dumas_degreeType&rows=70 -->
     <xsl:param name="degreeCode" select="'23'" />
     <!-- Lien vers le fichier PDF. Peut prendre la forme d'un lien ftp -->
@@ -39,28 +34,6 @@
 
         <xsl:call-template name="codeLangue">
             <xsl:with-param name="code" select="$mainTitleLang639_2"/>
-        </xsl:call-template>
-    </xsl:variable>
-
-    <!-- /!\ For development and tests purposes only. Will be overwrited by Oracle template -->
-    <!-- Récupération du code langue en 101$d ou en 541$z. Valeur par défaut = valeur du paramètre secondaryLanguage ou 'eng' -->
-    <xsl:variable name="secondaryLanguageCode">
-        <xsl:variable name="secondaryLanguageCode639_2">
-            <xsl:choose>
-                <xsl:when test="/record/datafield[@tag='101']/subfield[@code='d'][2]">
-                    <xsl:value-of select="/record/datafield[@tag='101']/subfield[@code='d'][2]" />
-                </xsl:when>
-                <xsl:when test="/record/datafield[@tag = '541']/subfield[@code = 'z'][1]">
-                    <xsl:value-of select="/record/datafield[@tag = '541']/subfield[@code = 'z'][1]" />
-                </xsl:when>
-                <xsl:otherwise>
-                    <xsl:value-of select="$secondaryLanguage" />
-                </xsl:otherwise>
-            </xsl:choose>
-        </xsl:variable>
-
-        <xsl:call-template name="codeLangue">
-            <xsl:with-param name="code" select="$secondaryLanguageCode639_2"/>
         </xsl:call-template>
     </xsl:variable>
 
@@ -245,18 +218,17 @@
         </xsl:if>
     </xsl:template>
 
-    <xsl:template name="abstract">
+    <xsl:template name="abstract"> 
         <xsl:for-each select="datafield[@tag = '330']/subfield[@code = 'a']">
-            <xsl:if test="position() = 1">
-                <abstract xml:lang="{$primaryLanguageCode}">
-                    <xsl:value-of select="." />
-                </abstract>
-            </xsl:if>
-            <xsl:if test="position() = 2">
-                <abstract xml:lang="{$secondaryLanguageCode}">
-                    <xsl:value-of select="." />
-                </abstract>
-            </xsl:if>
+            <xsl:variable name="abstractIndex" select="position()"/>
+            <xsl:variable name="abstractLang">
+                <xsl:call-template name="codeLangue">
+                    <xsl:with-param name="code" select="//datafield[@tag='101']/subfield[@code='d'][$abstractIndex]"/>
+                </xsl:call-template>
+            </xsl:variable>
+            <abstract xml:lang="{$abstractLang}">
+                <xsl:value-of select="." />
+            </abstract>
         </xsl:for-each>
     </xsl:template>
     

--- a/xslt/marcxml2tei-1.0.xsl
+++ b/xslt/marcxml2tei-1.0.xsl
@@ -18,25 +18,6 @@
     <!-- Date d'embargo  au format AAAA-MM-JJ -->
     <!--    <xsl:param name="embargoDate" select="format-date(current-date(),'[Y0001]-[M01]-[D01]')" />-->
 
-    <!-- /!\ For development and tests purposes only. Will be overwrited by Oracle template -->
-    <xsl:variable name="mainTitleLang">
-        <xsl:variable name="mainTitleLang639_2">
-            <xsl:choose>
-                <xsl:when test="count(/record/datafield[@tag='101']/subfield[@code='a']) = 1">
-                    <xsl:value-of select="/record/datafield[@tag='101']/subfield[@code='a'][1]"/>
-                </xsl:when>
-                <xsl:otherwise>
-                    <!-- Par défaut on considère que le document est en Français s'il y a plusieurs 101$a -->
-                    <xsl:text>fre</xsl:text>
-                </xsl:otherwise>
-            </xsl:choose>
-        </xsl:variable>
-
-        <xsl:call-template name="codeLangue">
-            <xsl:with-param name="code" select="$mainTitleLang639_2"/>
-        </xsl:call-template>
-    </xsl:variable>
-
     <xsl:variable name="IdRefBaseUrl" select="'https://www.idref.fr/'" />
 
     <xsl:template name="tei" match="record">
@@ -93,7 +74,24 @@
     </xsl:template>
 
     <xsl:template name="title">
-        <title xml:lang="{$mainTitleLang}">
+        <xsl:variable name="mainTitleLang">
+            <xsl:variable name="numberOfMainLang" select="count(/record/datafield[@tag='101']/subfield[@code='a'])" />
+            <xsl:variable name="mainTitleLang639_2">
+                <xsl:choose>
+                    <xsl:when test="$numberOfMainLang = 1">
+                        <xsl:value-of select="/record/datafield[@tag='101']//subfield[@code='a'][1]"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:text>fre</xsl:text>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:variable>
+    
+            <xsl:call-template name="codeLangue">
+                <xsl:with-param name="code" select="$mainTitleLang639_2"/>
+            </xsl:call-template>
+        </xsl:variable>
+        <title xml:lang='{$mainTitleLang}'>
             <xsl:call-template name="joinTitleElements">
                 <xsl:with-param name="titles" select="datafield[@tag = '200']/subfield[@code = 'a']" />
                 <xsl:with-param name="subtitles" select="datafield[@tag = '200']/subfield[@code = 'e']" />

--- a/xslt/marcxml2tei-2.0.xsl
+++ b/xslt/marcxml2tei-2.0.xsl
@@ -18,25 +18,8 @@
     <!-- Date d'embargo  au format AAAA-MM-JJ -->
     <xsl:param name="embargoDate" as="xs:string" required="no" select="format-date(current-date(),'[Y0001]-[M01]-[D01]')"/>
 
-    <!-- Récupération du code langue en 101$a. Valeur par défaut = valeur du paramètre primaryLanguage ou 'fre'-->
+    <!-- Récupération du code langue en 101$a. Valeur par défaut = 'fre'-->
     <xsl:variable name="mappingCodeLangue" select="document('code_langues.xml')" />
-    <xsl:variable name="mainTitleLang">
-        <xsl:variable name="mainTitleLang639_2">
-            <xsl:choose>
-                <xsl:when test="count(/record/datafield[@tag='101']/subfield[@code='a']) = 1">
-                    <xsl:value-of select="/record/datafield[@tag='101']/subfield[@code='a'][1]"/>
-                </xsl:when>
-                <xsl:otherwise>
-                    <!-- Par défaut on considère que le document est en Français s'il y a plusieurs 101$a -->
-                    <xsl:text>fre</xsl:text>
-                </xsl:otherwise>
-            </xsl:choose>
-        </xsl:variable>
-
-        <xsl:call-template name="codeLangue">
-            <xsl:with-param name="code" select="$mainTitleLang639_2"/>
-        </xsl:call-template>
-    </xsl:variable>
 
     <xsl:variable name="IdRefBaseUrl" select="'https://www.idref.fr/'"/>
 
@@ -94,6 +77,24 @@
     </xsl:template>
 
     <xsl:template name="title">
+        <xsl:variable name="mainTitleLang">
+            <xsl:variable name="numberOfMainLang" select="count(/record/datafield[@tag='101']/subfield[@code='a'])" />
+            <xsl:variable name="mainTitleLang639_2">
+                <xsl:choose>
+                    <xsl:when test="$numberOfMainLang=1">
+                        <xsl:value-of select="/record/datafield[@tag='101']//subfield[@code='a'][1]"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:text>fre</xsl:text>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:variable>
+    
+            <xsl:call-template name="codeLangue">
+                <xsl:with-param name="code" select="$mainTitleLang639_2"/>
+            </xsl:call-template>
+        </xsl:variable>
+
         <title xmlns="http://www.tei-c.org/ns/1.0" xml:lang="{$mainTitleLang}">
             <xsl:call-template name="joinTitleElements">
                 <xsl:with-param name="titles" select="datafield[@tag = '200']/subfield[@code = 'a']" />

--- a/xslt/marcxml2tei-2.0.xsl
+++ b/xslt/marcxml2tei-2.0.xsl
@@ -203,7 +203,7 @@
         <xsl:if test="$keywords">
             <keywords xmlns="http://www.tei-c.org/ns/1.0" scheme="author">
                 <xsl:for-each select="distinct-values($keywords)">
-                    <term xml:lang="{$primaryLanguageCode}">
+                    <term xml:lang="fr">
                         <xsl:value-of select="." />
                     </term>
                 </xsl:for-each>

--- a/xslt/marcxml2tei-2.0.xsl
+++ b/xslt/marcxml2tei-2.0.xsl
@@ -11,11 +11,6 @@
     <xsl:strip-space elements="*" />
     <xsl:output method="xml" indent="yes" />
     
-    <!-- Paramètres pouvant être modifiés par saxon : `saxon-xslt 252383524.xml mapping.xslt secondaryLanguageCode=es degreeCode=22 > output.tei`  -->
-    <!-- Langue principale du document. Au format ISO 639-2. Lorsqu'il est renseigné, ce paramètre n'est utilisé que s'il est impossible de trouver la langue principale du document-->
-    <xsl:param name="primaryLanguage" as="xs:string" required="no" select="'fre'"/>
-    <!-- Langue secondaire du document. Au format ISO 639-2. Lorsqu'il est renseigné, ce paramètre n'est utilisé que s'il est impossible de trouver la langue secondaire du document -->
-    <xsl:param name="secondaryLanguage" as="xs:string" required="no" select="'eng'"/>
     <!-- Liste des codes diplôme : https://api.archives-ouvertes.fr/ref/metadataList/?q=metaName_s:dumas_degreeType&rows=70 -->
     <xsl:param name="degreeCode" as="xs:string" required="no" select="'23'"/>
     <!-- Lien vers le fichier PDF. Peut prendre la forme d'un lien ftp -->
@@ -40,14 +35,6 @@
 
         <xsl:call-template name="codeLangue">
             <xsl:with-param name="code" select="$mainTitleLang639_2"/>
-        </xsl:call-template>
-    </xsl:variable>
-
-    <!-- Récupération du code langue en 101$d ou en 541$z. Valeur par défaut = valeur du paramètre secondaryLanguage ou 'eng' -->
-    <xsl:variable name="secondaryLanguageCode">
-        <xsl:variable name="secondaryLanguageCode639_2" select="(/record/datafield[@tag='101']/subfield[@code='d'][2], datafield[@tag = '541']/subfield[@code = 'z'], $secondaryLanguage)[1]"/>
-        <xsl:call-template name="codeLangue">
-            <xsl:with-param name="code" select="$secondaryLanguageCode639_2"/>
         </xsl:call-template>
     </xsl:variable>
 
@@ -230,18 +217,17 @@
         </xsl:if>
     </xsl:template>
 
-    <xsl:template name="abstract">
+    <xsl:template name="abstract"> 
         <xsl:for-each select="datafield[@tag = '330']/subfield[@code = 'a']">
-            <xsl:if test="position() = 1">
-                <abstract xmlns="http://www.tei-c.org/ns/1.0" xml:lang="{$primaryLanguageCode}">
-                    <xsl:value-of select="." />
-                </abstract>
-            </xsl:if>
-            <xsl:if test="position() = 2">
-                <abstract xmlns="http://www.tei-c.org/ns/1.0" xml:lang="{$secondaryLanguageCode}">
-                    <xsl:value-of select="." />
-                </abstract>
-            </xsl:if>
+            <xsl:variable name="abstractIndex" select="position()"/>
+            <xsl:variable name="abstractLang">
+                <xsl:call-template name="codeLangue">
+                    <xsl:with-param name="code" select="//datafield[@tag='101']/subfield[@code='d'][$abstractIndex]"/>
+                </xsl:call-template>
+            </xsl:variable>
+            <abstract xml:lang="{$abstractLang}">
+                <xsl:value-of select="." />
+            </abstract>
         </xsl:for-each>
     </xsl:template>
 


### PR DESCRIPTION
Fixe l'extraction des langues des titres, des résumés et des mots clés.

close #8 