### PR TITLE
Ajout de la syntaxe RAMEAU pour les mots clés

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "rameau"]
+	path = rameau
+	url = https://github.com/eonm-abes/rameau

--- a/template/bundle.xsl
+++ b/template/bundle.xsl
@@ -10,5 +10,6 @@
 
     <xi:include href="../commons/mapping_tel_domains_oai_sets.xsl" xpointer="xmlns(xsl=http://www.w3.org/1999/XSL/Transform)xpointer(//xsl:stylesheet/*[name() != 'xsl:output' and name() != 'xsl:strip-space'])"/>
     <xi:include href="../commons/code_langues.xsl" xpointer="xmlns(xsl=http://www.w3.org/1999/XSL/Transform)xpointer(//xsl:stylesheet/*[name() != 'xsl:output' and name() != 'xsl:strip-space'])"/>
+    <xi:include href="../rameau/xslt/xslt.xsl" xpointer="xmlns(xsl=http://www.w3.org/1999/XSL/Transform)xpointer(//xsl:stylesheet/*[name() != 'xsl:output' and name() != 'xsl:strip-space'])"/>
     <xi:include href="../xslt/marcxml2tei-1.0.xsl" xpointer="xmlns(xsl=http://www.w3.org/1999/XSL/Transform)xpointer(//xsl:stylesheet/*[(name() != 'xsl:import' and name() != 'xsl:output' and name() != 'xsl:strip-space') or (@name != 'codeOai' and @name != 'codeLangue')])"/>
 </xsl:stylesheet>

--- a/template/oracle.xsl
+++ b/template/oracle.xsl
@@ -24,5 +24,6 @@
 	</xsl:template>
 
 	<!-- Importe le contenu de ./xslt/marcxml2tei-1.0.xsl sauf le prologue xslt, primaryLanguageCode et secondaryLanguageCode -->
+	<xi:include href="../rameau/xslt/xslt.xsl" xpointer="xmlns(xsl=http://www.w3.org/1999/XSL/Transform)xpointer(//xsl:stylesheet/*[name() != 'xsl:output' and name() != 'xsl:strip-space'])"/>
 	<xi:include href="../xslt/marcxml2tei-1.0.xsl" xpointer="xmlns(xsl=http://www.w3.org/1999/XSL/Transform)xpointer(//xsl:stylesheet/*[(name() != 'xsl:import' and name() != 'xsl:output' and name() != 'xsl:strip-space') and (@name != 'codeOai' and @name != 'codeLangue')])"/>
 </xsl:stylesheet>

--- a/tests/marcxml2tei.xspec
+++ b/tests/marcxml2tei.xspec
@@ -404,4 +404,52 @@
             <abstract xmlns="http://www.tei-c.org/ns/1.0" xmlns:ext="http://exslt.org/common" xmlns:hal="http://hal.archives-ouvertes.fr/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:lang="en">Background: FVC and DLCO are the most useful physiological parameters to assess idiopathic pulmonary fibrosis (IPF). They are expressed as percentage of reference value or Z-score, and the use of Global Lung Initiative (GLI) equations is now recommended. The objectives were to describe the relationship between FVC and DLCO, and to assess the influence of the change in reference values on medical decision, namely regarding the selection of lung transplant candidates. Methods: we included all subjects diagnosed with IPF from the cohort COLIBRI-ILD. Measurements of FVC and DLCO performed at the same time were collected for each patient. Results: in 248 IPF patients with a broad range of severity, this transversal observation highlighted the nonlinear relationship between FVC and DLCO. Those results could allow us to characterise the course of FVC and DLCO throughout disease progression for a given patient. In the first stages, FVC would remain steady while DLCO would drop. In contrast, both would decline in the last stages. 17 patients switch group to be reffered to a lung transplant center when we use GLI instead of the older standards, with the cut-off limit of 40 % for DLCO or 80 % for FVC. Conclusion: DLCO seems essential in monitoring the IPF forms when FVC is preserved. The use of GLI is little more sensitive than older standards to select lung transplant candidates</abstract>
         </x:expect>
     </x:scenario>
+
+    <x:scenario label="Generating author keywords and RAMEAU keywords">
+        <x:context>
+            <record>
+                <datafield tag="606" ind1=" " ind2=" ">
+                    <subfield code="3">029474299</subfield>
+                    <subfield code="a">Syndromes des apnées du sommeil</subfield>
+                    <subfield code="3">027357236</subfield>
+                    <subfield code="x">Dépistage</subfield>
+                    <subfield code="2">rameau</subfield>
+                </datafield>
+                <datafield tag="606" ind1=" " ind2=" ">
+                    <subfield code="3">027338215</subfield>
+                    <subfield code="a">Médecins généralistes</subfield>
+                    <subfield code="3">027226794</subfield>
+                    <subfield code="y">France</subfield>
+                    <subfield code="3">027244938</subfield>
+                    <subfield code="y">Picardie (France)</subfield>
+                    <subfield code="2">rameau</subfield>
+                </datafield>
+                <datafield tag="608" ind1=" " ind2=" ">
+                    <subfield code="3">027253139</subfield>
+                    <subfield code="a">Thèses et écrits académiques</subfield>
+                    <subfield code="2">rameau</subfield>
+                </datafield>
+                <datafield tag="610" ind1="0" ind2=" ">
+                    <subfield code="a">Capacité de diffusion du poumon pour le monoxyde de carbone (DLCO)</subfield>
+                    <subfield code="a">Normes GLI</subfield>
+                    <subfield code="a">Global lung initiative (GLI)</subfield>
+                    <subfield code="a">Diffusing capacity of the lung for carbon monoxide (DLCO)</subfield>
+                </datafield>
+            </record>
+        </x:context>
+
+        <x:call template="keywords" />
+
+        <x:expect>
+            <keywords scheme="author" xmlns="http://www.tei-c.org/ns/1.0" xmlns:ext="http://exslt.org/common" xmlns:hal="http://hal.archives-ouvertes.fr/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <term xml:lang="fr">Syndromes des apnées du sommeil -- Dépistage</term>
+                <term xml:lang="fr">Médecins généralistes -- France -- Picardie (France)</term>
+                <term xml:lang="fr">Thèses et écrits académiques</term>
+                <term xml:lang="fr">Capacité de diffusion du poumon pour le monoxyde de carbone (DLCO)</term>
+                <term xml:lang="fr">Normes GLI</term>
+                <term xml:lang="fr">Global lung initiative (GLI)</term>
+                <term xml:lang="fr">Diffusing capacity of the lung for carbon monoxide (DLCO)</term>
+            </keywords>
+        </x:expect>
+    </x:scenario>
 </x:description>

--- a/xslt/marcxml2tei-1.0.xsl
+++ b/xslt/marcxml2tei-1.0.xsl
@@ -200,116 +200,68 @@
         <xsl:variable name="keywords" select="datafield[@tag = '600' or @tag = '601' or @tag = '602' or @tag = '604' or @tag = '605' or @tag = '606' or @tag = '607' or @tag = '608' or @tag = '610']"/>
         <xsl:if test="$keywords">
             <keywords scheme="author">
-                <!-- deduplicate keywords-->
-                <!-- <xsl:for-each select="$keywords"> -->
-                    <!-- <term xml:lang="fr"> -->
-                        <!-- <xsl:choose>
-                            <xsl:when test=".[@tag = '600']"> -->
-                                <xsl:variable name="S600">    
-                                    <xsl:call-template name="R600"/>
-                                </xsl:variable>
-    
-                                <xsl:if test="$S600 != ''">
-                                    <term xml:lang="fr">
-                                        <xsl:value-of select="$S600"/>
-                                    </term>
-                                </xsl:if>
-    
-                                <xsl:variable name="S601">
-                                    <xsl:call-template name="R601"/>
-                                </xsl:variable>
-    
-                                <xsl:if test="$S601 != ''">
-                                    <term xml:lang="fr">
-                                        <xsl:value-of select="$S601"/>
-                                    </term>
-                                </xsl:if>
-    
-                                <xsl:variable name="S602">
-                                    <xsl:call-template name="R602"/>
-                                </xsl:variable>
-    
-                                <xsl:if test="$S602 != ''">
-                                    <term xml:lang="fr">
-                                        <xsl:value-of select="$S602"/>
-                                    </term>
-                                </xsl:if>
-    
-                                <xsl:variable name="S604">
-                                    <xsl:call-template name="R604"/>
-                                </xsl:variable>
-    
-                                <xsl:if test="$S604 != ''">
-                                    <term xml:lang="fr">
-                                        <xsl:value-of select="$S604"/>
-                                    </term>
-                                </xsl:if>
-    
-                                <xsl:variable name="S605">
-                                    <xsl:call-template name="R605"/>
-                                </xsl:variable>
-    
-                                <xsl:if test="$S605 != ''">
-                                    <xsl:for-each select="$S605">
-                                        <term xml:lang="fr">
-                                            <xsl:value-of select="."/>
-                                        </term>
-                                    </xsl:for-each>
-                                </xsl:if>
-    
-                                <xsl:variable name="S606">
-                                    <xsl:call-template name="R606"/>
-                                </xsl:variable>
-    
-                                <xsl:if test="$S606 != ''">
-                                    <xsl:for-each select="$S606">
-                                        <term xml:lang="fr">
-                                            <xsl:value-of select="."/>
-                                        </term>
-                                    </xsl:for-each>
-                                </xsl:if>
-    
-                                <xsl:variable name="S607">
-                                    <xsl:call-template name="R607"/>
-                                </xsl:variable>
-    
-                                <xsl:if test="$S607 != ''">
-                                    <xsl:for-each select="$S607">
-                                        <term xml:lang="fr">
-                                            <xsl:value-of select="."/>
-                                        </term>
-                                    </xsl:for-each>
-                                </xsl:if>
-    
-                                <xsl:variable name="S608">
-                                    <xsl:call-template name="R608"/>
-                                </xsl:variable>
-    
-                                <xsl:if test="$S608 != ''">
-                                    <xsl:for-each select="$S608">
-                                        <term xml:lang="fr">
-                                            <xsl:value-of select="."/>
-                                        </term>
-                                    </xsl:for-each>
-                                </xsl:if>
-<!--     
-                                <xsl:variable name="S610">
-                                    <xsl:call-template name="R610"/>
-                                </xsl:variable> -->
+                <xsl:for-each select="$keywords">
+                    <xsl:variable name="keyword">
+                        <xsl:choose>
+                            <xsl:when test=".[@tag = '600']">
+                                <xsl:call-template name="R600">
+                                    <xsl:with-param name="field" select="." />
+                                </xsl:call-template>  
+                            </xsl:when>
+                            <xsl:when test=".[@tag = '601']">
+                                <xsl:call-template name="R601">
+                                    <xsl:with-param name="field" select="." />
+                                </xsl:call-template>
+                            </xsl:when>
+                            <xsl:when test=".[@tag = '602']">
+                                <xsl:call-template name="R602">
+                                    <xsl:with-param name="field" select="." />
+                                </xsl:call-template>
+                            </xsl:when>
+                            <xsl:when test=".[@tag = '604']">
+                                <xsl:call-template name="R604">
+                                    <xsl:with-param name="field" select="." />
+                                </xsl:call-template>
+                            </xsl:when>
+                            <xsl:when test=".[@tag = '605']">
+                                <xsl:call-template name="R605">
+                                    <xsl:with-param name="field" select="." />
+                                </xsl:call-template>
+                            </xsl:when>
+                            <xsl:when test=".[@tag = '606']">
+                                <xsl:call-template name="R606">
+                                    <xsl:with-param name="field" select="." />
+                                </xsl:call-template>
+                            </xsl:when>
+                            <xsl:when test=".[@tag = '607']">
+                                <xsl:call-template name="R607">
+                                    <xsl:with-param name="field" select="." />
+                                </xsl:call-template>
+                            </xsl:when>
+                            <xsl:when test=".[@tag = '608']">
+                                <xsl:call-template name="R608">
+                                    <xsl:with-param name="field" select="." />
+                                </xsl:call-template>
+                            </xsl:when>
+                        </xsl:choose>
+                    </xsl:variable>
 
-                            <!-- <xsl:if test="$610 != ''">
+                    <xsl:if test="$keyword != ''">
+                        <term xml:lang="fr">
+                            <xsl:value-of select="$keyword"/>
+                        </term>
+                    </xsl:if>
+
+                    <xsl:if test=".[@tag = '610']">
+                        <xsl:for-each select="subfield[@code = 'a']">
+                            <xsl:if test=".!= ''">
                                 <term xml:lang="fr">
-                                    <xsl:value-of select="$610"/>
+                                    <xsl:value-of select="."/>
                                 </term>
-                            </xsl:if> -->
-
-
-                            <!-- <xsl:when test=".[@tag = '610']">
-                                <xsl:value-of select="subfield[@code = 'a']" />
-                            </xsl:when> -->
-                        <!-- </xsl:choose> -->
-                    <!-- </term> -->
-                <!-- </xsl:for-each> -->
+                            </xsl:if>
+                        </xsl:for-each>
+                    </xsl:if>
+                </xsl:for-each>
             </keywords>
         </xsl:if>
     </xsl:template>

--- a/xslt/marcxml2tei-1.0.xsl
+++ b/xslt/marcxml2tei-1.0.xsl
@@ -197,15 +197,119 @@
     </xsl:template>
 
     <xsl:template name="keywords">
-        <xsl:variable name="keywords" select="(datafield[@tag = '610' or @tag = '606' or @tag = '607']/subfield[@code = 'a'])[not(preceding::datafield[@tag = '610' or @tag = '606' or @tag = '607']/subfield[@code = 'a']/. = .)]"/>
+        <xsl:variable name="keywords" select="datafield[@tag = '600' or @tag = '601' or @tag = '602' or @tag = '604' or @tag = '605' or @tag = '606' or @tag = '607' or @tag = '608' or @tag = '610']"/>
         <xsl:if test="$keywords">
             <keywords scheme="author">
                 <!-- deduplicate keywords-->
-                <xsl:for-each select="$keywords">
-                    <term xml:lang="fr">
-                        <xsl:value-of select="." />
-                    </term>
-                </xsl:for-each>
+                <!-- <xsl:for-each select="$keywords"> -->
+                    <!-- <term xml:lang="fr"> -->
+                        <!-- <xsl:choose>
+                            <xsl:when test=".[@tag = '600']"> -->
+                                <xsl:variable name="S600">    
+                                    <xsl:call-template name="R600"/>
+                                </xsl:variable>
+    
+                                <xsl:if test="$S600 != ''">
+                                    <term xml:lang="fr">
+                                        <xsl:value-of select="$S600"/>
+                                    </term>
+                                </xsl:if>
+    
+                                <xsl:variable name="S601">
+                                    <xsl:call-template name="R601"/>
+                                </xsl:variable>
+    
+                                <xsl:if test="$S601 != ''">
+                                    <term xml:lang="fr">
+                                        <xsl:value-of select="$S601"/>
+                                    </term>
+                                </xsl:if>
+    
+                                <xsl:variable name="S602">
+                                    <xsl:call-template name="R602"/>
+                                </xsl:variable>
+    
+                                <xsl:if test="$S602 != ''">
+                                    <term xml:lang="fr">
+                                        <xsl:value-of select="$S602"/>
+                                    </term>
+                                </xsl:if>
+    
+                                <xsl:variable name="S604">
+                                    <xsl:call-template name="R604"/>
+                                </xsl:variable>
+    
+                                <xsl:if test="$S604 != ''">
+                                    <term xml:lang="fr">
+                                        <xsl:value-of select="$S604"/>
+                                    </term>
+                                </xsl:if>
+    
+                                <xsl:variable name="S605">
+                                    <xsl:call-template name="R605"/>
+                                </xsl:variable>
+    
+                                <xsl:if test="$S605 != ''">
+                                    <xsl:for-each select="$S605">
+                                        <term xml:lang="fr">
+                                            <xsl:value-of select="."/>
+                                        </term>
+                                    </xsl:for-each>
+                                </xsl:if>
+    
+                                <xsl:variable name="S606">
+                                    <xsl:call-template name="R606"/>
+                                </xsl:variable>
+    
+                                <xsl:if test="$S606 != ''">
+                                    <xsl:for-each select="$S606">
+                                        <term xml:lang="fr">
+                                            <xsl:value-of select="."/>
+                                        </term>
+                                    </xsl:for-each>
+                                </xsl:if>
+    
+                                <xsl:variable name="S607">
+                                    <xsl:call-template name="R607"/>
+                                </xsl:variable>
+    
+                                <xsl:if test="$S607 != ''">
+                                    <xsl:for-each select="$S607">
+                                        <term xml:lang="fr">
+                                            <xsl:value-of select="."/>
+                                        </term>
+                                    </xsl:for-each>
+                                </xsl:if>
+    
+                                <xsl:variable name="S608">
+                                    <xsl:call-template name="R608"/>
+                                </xsl:variable>
+    
+                                <xsl:if test="$S608 != ''">
+                                    <xsl:for-each select="$S608">
+                                        <term xml:lang="fr">
+                                            <xsl:value-of select="."/>
+                                        </term>
+                                    </xsl:for-each>
+                                </xsl:if>
+<!--     
+                                <xsl:variable name="S610">
+                                    <xsl:call-template name="R610"/>
+                                </xsl:variable> -->
+
+                            <!-- <xsl:if test="$610 != ''">
+                                <term xml:lang="fr">
+                                    <xsl:value-of select="$610"/>
+                                </term>
+                            </xsl:if> -->
+
+
+                            <!-- <xsl:when test=".[@tag = '610']">
+                                <xsl:value-of select="subfield[@code = 'a']" />
+                            </xsl:when> -->
+                        <!-- </xsl:choose> -->
+                    <!-- </term> -->
+                <!-- </xsl:for-each> -->
             </keywords>
         </xsl:if>
     </xsl:template>


### PR DESCRIPTION
Ajout de la syntaxe Rameau pour les mots clés
- [x] ajout du sous module pour la génération de la syntaxe RAMEAU
- [x] tests unitaires