### PR TITLE
fix: removing automatic date formating to YYYY-MM-DD

### DIFF
--- a/tests/marcxml2tei.xspec
+++ b/tests/marcxml2tei.xspec
@@ -212,7 +212,7 @@
         <x:expect label="Should display monogr data.">
             <monogr xmlns="http://www.tei-c.org/ns/1.0" xmlns:ext="http://exslt.org/common" xmlns:hal="http://hal.archives-ouvertes.fr/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
                 <imprint>
-                    <date type="dateDefended">2020-01-01</date>
+                    <date type="dateDefended">2020</date>
                 </imprint>
                 <authority type="institution">Université Sorbonne Paris Cité</authority>
                 <authority type="supervisor">Monique Sélim</authority>
@@ -226,40 +226,6 @@
                 <authority type="jury">Yann Moulier Boutang</authority>
                 <authority type="jury">Catherine Agulhon</authority>
                 <authority type="jury">Annie Benveniste</authority>
-            </monogr>
-        </x:expect>
-    </x:scenario>
-
-    <x:scenario label="Monog with incomplete defense date.">
-        <x:context>
-            <record>
-                <datafield tag="328" ind1=" " ind2="1">
-                    <subfield code="d">2020</subfield>
-                </datafield>
-                <datafield tag="711" ind1="0" ind2="2">
-                    <subfield code="3">026402920</subfield>
-                    <subfield code="a">Université d&apos;Angers</subfield>
-                    <subfield code="4">295</subfield>
-                </datafield>
-                <datafield tag="701" ind1=" " ind2="1">
-                    <subfield code="3">031290035</subfield>
-                    <subfield code="a">Bellamy</subfield>
-                    <subfield code="b">David</subfield>
-                    <subfield code="f">1965-....</subfield>
-                    <subfield code="4">727</subfield>
-                </datafield>
-            </record>
-        </x:context>
-
-        <x:call template="monogr" />
-
-        <x:expect label="Defense date YYYY should be reformated automatically to YYY-MM-DD.">
-            <monogr xmlns="http://www.tei-c.org/ns/1.0" xmlns:ext="http://exslt.org/common" xmlns:hal="http://hal.archives-ouvertes.fr/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-                <imprint>
-                    <date type="dateDefended">2020-01-01</date>
-                </imprint>
-                <authority type="institution">Université d'Angers</authority>
-                <authority type="supervisor">David Bellamy</authority>
             </monogr>
         </x:expect>
     </x:scenario>
@@ -290,7 +256,7 @@
         <x:expect label="Authority with invalid function code shouldn't show up.">
             <monogr xmlns="http://www.tei-c.org/ns/1.0" xmlns:ext="http://exslt.org/common" xmlns:hal="http://hal.archives-ouvertes.fr/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
                 <imprint>
-                    <date type="dateDefended">2020-01-01</date>
+                    <date type="dateDefended">2020</date>
                 </imprint>
             </monogr>
         </x:expect>

--- a/xslt/marcxml2tei-1.0.xsl
+++ b/xslt/marcxml2tei-1.0.xsl
@@ -144,9 +144,7 @@
                     </biblScope>
                 </xsl:if>
                 <date type="dateDefended">
-                    <xsl:call-template name="formatDate">
-                        <xsl:with-param name="date" select="(datafield[@tag = '328']/subfield[@code = ('d')])[1]" />
-                    </xsl:call-template>
+                    <xsl:value-of select="(datafield[@tag = '328']/subfield[@code = ('d')])[1]" />
                 </date>
             </imprint>
             <xsl:if test="datafield[@tag = '711'][subfield[@code = '4'] = '295']">
@@ -371,15 +369,5 @@
                 <xsl:value-of select="$input" />
             </xsl:otherwise>
         </xsl:choose>
-    </xsl:template>
-
-    <xsl:template name="formatDate">
-        <xsl:param name="date" />
-        <xsl:if test="string-length($date) = 4">
-            <xsl:value-of select="concat($date, '-01-01')" />
-        </xsl:if>
-        <xsl:if test="string-length($date) > 4">
-            <xsl:value-of select="$date" />
-        </xsl:if>
     </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
Les dates ne sont plus reformatées automatiquement au format AAAA-MM-JJ lorsqu'il n'y a qu'une année de soutenance dans les données.

closing #13 